### PR TITLE
Add a getter to BitmapDrawablePlaceHolder to get the actual drawable

### DIFF
--- a/library/src/main/java/com/commit451/bypasspicassoimagegetter/BypassPicassoImageGetter.java
+++ b/library/src/main/java/com/commit451/bypasspicassoimagegetter/BypassPicassoImageGetter.java
@@ -117,5 +117,8 @@ public class BypassPicassoImageGetter implements Bypass.ImageGetter {
             this.drawable = drawable;
         }
 
+        public Drawable getDrawable() {
+            return drawable;
+        }
     }
 }


### PR DESCRIPTION
The getter is required because the object that click listener receives is of type BitmapDrawablePlaceHolder and cannot be converted to a bitmap

This PR is in conjunction with https://github.com/Commit451/bypasses/pull/5